### PR TITLE
fixed the end_chromosome problem

### DIFF
--- a/loqusdb/plugins/mongo/structural_variant.py
+++ b/loqusdb/plugins/mongo/structural_variant.py
@@ -215,7 +215,7 @@ class SVMixin():
         if chromosome:
             query['chrom'] = chromosome
         if end_chromosome:
-            query['end_chrom'] = chromosome
+            query['end_chrom'] = end_chromosome
         if sv_type:
             query['sv_type'] = sv_type
         if pos:

--- a/loqusdb/plugins/mongo/structural_variant.py
+++ b/loqusdb/plugins/mongo/structural_variant.py
@@ -88,7 +88,7 @@ class SVMixin():
         # We need to calculate the new cluster length
         if cluster['sv_type'] != 'BND':
             cluster_len = end_mean - pos_mean
-            interval_size = int(min(round(cluster_len/10, -2), max_window))
+            interval_size = int(min(round(cluster_len/4, -2), max_window))
         else:
             # Set length to a huge number that mongodb can handle, float('inf') would not work.
             cluster_len = 10e10

--- a/tests/plugins/mongo/test_get_sv.py
+++ b/tests/plugins/mongo/test_get_sv.py
@@ -15,3 +15,19 @@ def test_get_insertion(small_insert_variant, mongo_adapter, case_obj):
     adapter.add_structural_variant(formated_variant)
     for variant_obj in adapter.db.structural_variant.find():
         assert variant_obj
+
+def test_get_translocation(translocation_variant, mongo_adapter, case_obj):
+    adapter = mongo_adapter
+    ## GIVEN a mongo adapter with a translocation
+    variant = translocation_variant
+    case_id = case_obj['case_id']
+    formated_variant = build_variant(
+        variant=variant,
+        case_obj=case_obj,
+        case_id=case_id
+    )
+    
+    adapter.add_case(case_obj)
+    adapter.add_structural_variant(formated_variant)
+    for variant_obj in adapter.db.structural_variant.find():
+        assert variant_obj


### PR DESCRIPTION
Now it works!

loqusdb variants -t sv --chromosome 5 --end-chromosome 10

 Find all sv variants {'chrom': '5', 'end_chrom': '10'}
{'_id': ObjectId('5b2057c0e181b325cb7bc536'),
 'chrom': '5',
 'end_chrom': '10',
 'end_left': 68944905,
 'end_right': 68952905,
 'end_sum': 68948905,
 'families': ['b'],
 'length': 100000000000.0,
 'nr_events': 1,
 'pos_left': 39783793,
 'pos_right': 39791793,
 'pos_sum': 39787793,
 'sv_type': 'BND'}

